### PR TITLE
Update Events.php

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -110,8 +110,10 @@ class Events
 
         // Allow legal module usage
         if ($event->action->controller->module->id === 'legal') {
-            $event->sender->layout = '@user/views/layouts/main';
-            $event->sender->subLayout = '@legal/views/page/layout_login';
+            if (Yii::$app->controller->id === 'page') {
+                $event->sender->layout = '@user/views/layouts/main';
+                $event->sender->subLayout = '@legal/views/page/layout_login';
+            }
             return;
         }
 


### PR DESCRIPTION
If age verification was disabled and an admin enable it, `hasOpenCheck` returns true, but no redirection to check age will be done. So AdminController should not have a simplified layout wich must be reserved for PageController.