### PR TITLE
Enh: Apply header tags to $page->title

### DIFF
--- a/views/page/confirm.php
+++ b/views/page/confirm.php
@@ -18,7 +18,7 @@ use humhub\modules\content\widgets\richtext\RichText;
 
 <div class="panel">
     <div class="panel-heading">
-        <?= $page->title; ?>
+        <h2><?= $page->title; ?></h2>
     </div>
     <div class="panel-body">
         <?= RichText::output($page->content); ?>

--- a/views/page/update.php
+++ b/views/page/update.php
@@ -17,7 +17,7 @@ use humhub\modules\content\widgets\richtext\RichText;
 
 <div class="panel">
     <div class="panel-heading">
-        <?= $page->title; ?>
+        <h2><?= $page->title; ?></h2>
     </div>
     <div class="panel-body">
         <?= RichText::output($page->content); ?>

--- a/views/page/view.php
+++ b/views/page/view.php
@@ -18,7 +18,7 @@ use yii\bootstrap\Html;
         <?php if ($canManagePages): ?>
             <?= Html::a('Edit this page', ['/legal/admin/page', 'pageKey' => $page->page_key], ['class' => 'btn btn-default pull-right', 'data-ui-loader' => '']); ?>
         <?php endif; ?>
-        <?= $page->title; ?>
+        <h2><?= $page->title; ?></h2>
     </div>
     <div class="panel-body">
         <?= RichText::output($page->content); ?>


### PR DESCRIPTION
Currently, the `$page->title` just shows as normal text in which case it should be shown as a header