### PR TITLE
Wait for select2 to be loaded

### DIFF
--- a/views/admin/page.php
+++ b/views/admin/page.php
@@ -68,9 +68,14 @@ use yii\bootstrap\ActiveForm;
 
     <script <?= Html::nonce() ?>>
         showLanguage();
-        $("#pageLangSelector").select2().on("select2:select", function (e) {
-            showLanguage();
-        });
+        var select2Interval = setInterval(function() {
+            if(jQuery.fn.select2) {
+                clearInterval(select2Interval);
+                $("#pageLangSelector").select2().on("select2:select", function (e) {
+                    showLanguage();
+                });
+            }
+        }, 50 );
 
         function showLanguage() {
             curLang = $('#pageLangSelector').val();


### PR DESCRIPTION
If the configuration page is loaded (legal/admin) and the user changes to the "Terms and conditions" tab, they can change the language.
If the "Terms and conditions" tab is loaded "directly" (via legal/admin/page?pageKey=terms), select2 is not there initially. Changing languages is not possible, as the listener is not set.