### PR TITLE
Rename column 'last_update' to 'updated_at'

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 Changelog
 =========
+- Fix #74: save datetime of last update of a page
 
 1.4.1 (November 28, 2023)
 -------------------------

--- a/migrations/m240510_161238_fix_updated_at.php
+++ b/migrations/m240510_161238_fix_updated_at.php
@@ -1,0 +1,27 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m240510_161238_fix_updated_at
+ */
+class m240510_161238_fix_updated_at extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up()
+    {
+        $this->renameColumn('legal_page', 'last_update', 'updated_at');
+        $this->alterColumn('legal_page', 'updated_at', 'datetime');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function down()
+    {
+        $this->renameColumn('legal_page', 'updated_at', 'last_update');
+        $this->alterColumn('legal_page', 'last_update', 'int');
+    }
+}


### PR DESCRIPTION
... and change type to 'datetime'

It seems the column 'last_update' was not used at all and was always null.
By renaming the column to 'updated_at' the datetime is saved automatically (handled by https://github.com/humhub/humhub/blob/master/protected/humhub/components/ActiveRecord.php)